### PR TITLE
Added spaces to ":", Fix parsing issues, Fix issue with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 before_install:
 - if [ "$QT_BASE" = "52" ]; then sudo add-apt-repository ppa:beineri/opt-qt521 -y; fi
 - if [ "$QT_BASE" = "53" ]; then sudo add-apt-repository ppa:beineri/opt-qt532 -y; fi
-- if [ "$QT_BASE" = "54" ]; then sudo add-apt-repository ppa:beineri/opt-qt541 -y; fi
+- if [ "$QT_BASE" = "54" ]; then sudo add-apt-repository ppa:beineri/opt-qt542 -y; fi
 - if [ "$QT_BASE" = "55" ]; then sudo add-apt-repository ppa:beineri/opt-qt55 -y; fi
 
 install:

--- a/src/core/qmjsontype_qmjsonobject.cpp
+++ b/src/core/qmjsontype_qmjsonobject.cpp
@@ -169,7 +169,7 @@ QString QM_JSON_EXPORT QMJsonType<QMPointer<QMJsonObject> >::toJson(int32_t tab,
                     json += space;
                     json += '"';
                     json += iter.key();
-                    json += "\":";
+                    json += "\" : ";
                     json += iter.value()->toJson((QMJsonFormat)tab, sort);
                     json += ',';
 
@@ -192,7 +192,7 @@ QString QM_JSON_EXPORT QMJsonType<QMPointer<QMJsonObject> >::toJson(int32_t tab,
                     json += space;
                     json += '"';
                     json += key;
-                    json += "\":";
+                    json += "\" : ";
                     json += value->toJson((QMJsonFormat)tab, sort);
                     json += ',';
                 }

--- a/src/core/qmjsonvalue.cpp
+++ b/src/core/qmjsonvalue.cpp
@@ -918,7 +918,14 @@ QMPointer<QMJsonValue> QMJsonValue::fromJson(const QString &json)
         if (index >= json.length())
             return QMPointer<QMJsonValue>();
 
-        return QMJsonValue::fromJson(json, index);
+        value = QMJsonValue::fromJson(json, index);
+
+        QMJsonValue::skipSpaces(json, index);
+
+        if (index != json.length())
+            return QMPointer<QMJsonValue>();
+
+        return value;
     }
 
     catch (const QString &str)

--- a/test/testvalue.cpp
+++ b/test/testvalue.cpp
@@ -1330,18 +1330,18 @@ void TestJson::QMJsonValue_tofromjson_object(void)
 
     QVERIFY(pjson1 == "{}");
     QVERIFY(pjson2 == "{\n"
-            "    \"key0\":null,\n"
-            "    \"key1\":true,\n"
-            "    \"key2\":4.8,\n"
-            "    \"key3\":\"test\"\n"
+            "    \"key0\" : null,\n"
+            "    \"key1\" : true,\n"
+            "    \"key2\" : 4.8,\n"
+            "    \"key3\" : \"test\"\n"
             "}");
     QVERIFY(pjson3 == "{\n"
-            "    \"key4\":{},\n"
-            "    \"key5\":{\n"
-            "        \"key0\":null,\n"
-            "        \"key1\":true,\n"
-            "        \"key2\":4.8,\n"
-            "        \"key3\":\"test\"\n"
+            "    \"key4\" : {},\n"
+            "    \"key5\" : {\n"
+            "        \"key0\" : null,\n"
+            "        \"key1\" : true,\n"
+            "        \"key2\" : 4.8,\n"
+            "        \"key3\" : \"test\"\n"
             "    }\n"
             "}");
 

--- a/test/testvalue.cpp
+++ b/test/testvalue.cpp
@@ -1361,4 +1361,7 @@ void TestJson::QMJsonValue_fromjson(void)
     QVERIFY(QMJsonValue::fromJson("talse").isNull() == true);
     QVERIFY(QMJsonValue::fromJson("frue").isNull() == true);
     QVERIFY(QMJsonValue::fromJson("000pppsssss").isNull() == true);
+    QVERIFY(QMJsonValue::fromJson("\"\"invalid").isNull() == true);
+    QVERIFY(QMJsonValue::fromJson("[]invalid").isNull() == true);
+    QVERIFY(QMJsonValue::fromJson("{}invalid").isNull() == true);
 }


### PR DESCRIPTION
When performing toJson(QMJsonFormat_Pretty), QMJsonObject would
output ":" instead of " : ". This commit changes that.

Signed-off-by: Rian Quinn quinnr@ainfosec.com
