### PR TITLE
Fix compilation issue when GUI is disabled

### DIFF
--- a/example/example.pro
+++ b/example/example.pro
@@ -32,8 +32,19 @@ SOURCES += main.cpp
 # QMJson Required
 #-------------------------------------------------------------------------------
 
+!contains(QT_MODULES, gui) {
+
+    QT -= gui
+    DEFINES += DISABLE_QMJSON_GUI
+
+    LIBS += -lqmjson
+
+} else {
+
+    LIBS += -lqmjson -lqmjsongui
+}
+
 CONFIG += c++11
-LIBS += -lqmjson -lqmjsongui
 
 #-------------------------------------------------------------------------------
 # Clean

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -19,10 +19,18 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#include <QtGui>
+#ifndef DISABLE_QMJSON_GUI
 
+#include <QtGui>
 #include <qmjson.h>
 #include <qmjsongui.h>
+
+#else
+
+#include <QtCore>
+#include <qmjson.h>
+
+#endif
 
 int main(int argc, char const *argv[])
 {
@@ -33,10 +41,14 @@ int main(int argc, char const *argv[])
     // Setup
     //--------------------------------------------------------------------------
 
+#ifndef DISABLE_QMJSON_GUI
+
     QMJsonValue::registerFromComplexJson("QColor", &QMJsonType<QColor>::fromComplexJson);
     QMJsonValue::registerFromComplexJson("QPoint", &QMJsonType<QPoint>::fromComplexJson);
     QMJsonValue::registerFromComplexJson("QRect", &QMJsonType<QRect>::fromComplexJson);
     QMJsonValue::registerFromComplexJson("QSize", &QMJsonType<QSize>::fromComplexJson);
+
+#endif
 
     auto value1 = QMPointer<QMJsonValue>(new QMJsonValue(5.5));
     auto value2 = QMPointer<QMJsonValue>(new QMJsonValue("Hello"));
@@ -57,10 +69,14 @@ int main(int argc, char const *argv[])
     tree->insert("array", array);
     tree->insert("object", object);
 
+#ifndef DISABLE_QMJSON_GUI
+
     auto complexValue1 = QMPointer<QMJsonValue>(new QMJsonValue(QColor("red")));
     auto complexValue2 = QMPointer<QMJsonValue>(new QMJsonValue(QPoint(2, 2)));
     auto complexValue3 = QMPointer<QMJsonValue>(new QMJsonValue(QRect(5, 5, 3, 3)));
     auto complexValue4 = QMPointer<QMJsonValue>(new QMJsonValue(QSize(10, 10)));
+
+#endif
 
     //--------------------------------------------------------------------------
     // Valid
@@ -168,6 +184,7 @@ int main(int argc, char const *argv[])
     // Complex Types
     //--------------------------------------------------------------------------
 
+#ifndef DISABLE_QMJSON_GUI
 
     qDebug() << "Complex Values:";
     qDebug() << complexValue1;
@@ -210,6 +227,8 @@ int main(int argc, char const *argv[])
     qDebug() << QMJsonValue::fromJson(complexValue3->toJson());
     qDebug() << QMJsonValue::fromJson(complexValue4->toJson());
     qDebug() << "";
+
+#endif
 
     return 0;
 }

--- a/src/core/core.pro
+++ b/src/core/core.pro
@@ -32,6 +32,12 @@ TARGET = qmjson
 FEATURES = ../../include/qmjsonfeatures.h
 write_file($$FEATURES);
 
+!contains(QT_MODULES, gui) {
+
+    QT -= gui
+    DEFINES += DISABLE_QMJSON_GUI
+}
+
 contains(QT_MODULES, dbus) {
 
     QT += dbus

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -29,10 +29,14 @@ void TestJson::initTestCase(void)
 {
     qInstallMessageHandler(noMessageOutput);
 
+#ifndef DISABLE_QMJSON_GUI
+
     QMJsonValue::registerFromComplexJson("QColor", &QMJsonType<QColor>::fromComplexJson);
     QMJsonValue::registerFromComplexJson("QPoint", &QMJsonType<QPoint>::fromComplexJson);
     QMJsonValue::registerFromComplexJson("QRect", &QMJsonType<QRect>::fromComplexJson);
     QMJsonValue::registerFromComplexJson("QSize", &QMJsonType<QSize>::fromComplexJson);
+
+#endif
 }
 
 void TestJson::signaled(void)

--- a/test/test.h
+++ b/test/test.h
@@ -21,8 +21,18 @@
 
 #include <QtTest/QtTest>
 
+#ifndef DISABLE_QMJSON_GUI
+
+#include <QtGui>
 #include <qmjson.h>
 #include <qmjsongui.h>
+
+#else
+
+#include <QtCore>
+#include <qmjson.h>
+
+#endif
 
 class TestJson: public QObject
 {
@@ -103,10 +113,14 @@ private slots:
     virtual void QMJsonObject_custom(void);
     virtual void QMJsonObject_signals(void);
 
+#ifndef DISABLE_QMJSON_GUI
+
     virtual void QMJsonGui_qsize(void);
     virtual void QMJsonGui_qpoint(void);
     virtual void QMJsonGui_qrect(void);
     virtual void QMJsonGui_qcolor(void);
+
+#endif
 
     virtual void signaled(void);
 

--- a/test/test.pro
+++ b/test/test.pro
@@ -38,8 +38,19 @@ SOURCES += testgui.cpp
 # QMJson Required
 #-------------------------------------------------------------------------------
 
+!contains(QT_MODULES, gui) {
+
+    QT -= gui
+    DEFINES += DISABLE_QMJSON_GUI
+
+    LIBS += -lqmjson
+
+} else {
+
+    LIBS += -lqmjson -lqmjsongui
+}
+
 CONFIG += c++11
-LIBS += -lqmjson -lqmjsongui
 
 #-------------------------------------------------------------------------------
 # Clean

--- a/test/testgui.cpp
+++ b/test/testgui.cpp
@@ -21,6 +21,8 @@
 
 #include <test.h>
 
+#ifndef DISABLE_QMJSON_GUI
+
 void TestJson::QMJsonGui_qsize(void)
 {
     auto value00 = QMPointer<QMJsonValue>(new QMJsonValue(QSize()));
@@ -120,3 +122,4 @@ void TestJson::QMJsonGui_qcolor(void)
     QVERIFY(QMJsonValue::fromJson(pjson04)->to<QColor>(QColor()) == color04);
 }
 
+#endif


### PR DESCRIPTION
When QT is compiled without GUI support, the QMJson Library
was not compiling correctly because it was not properly turning
off support for GUI. This patch fixes that problem by explicitly
telling QT to remove GUI support, and then also adds a define
that can be used by the example code, and the test logic to
detect a lack of GUI support, and disable it's use as well.

Signed-off-by: Rian Quinn quinnr@ainfosec.com
