### PR TITLE
Small fixes

### DIFF
--- a/src/core/qmjsonarray.cpp
+++ b/src/core/qmjsonarray.cpp
@@ -50,7 +50,7 @@ void QMJsonArray::reserve(int32_t alloc)
 
 void QMJsonArray::clear(void)
 {
-    for (const auto &value : mList)
+    foreach (const auto &value, mList)
     {
         if (value->isObject() == true)
         {
@@ -153,7 +153,7 @@ void QMJsonArray::unite(const QMPointer<QMJsonArray> &array, QMJsonArrayUnitePol
     if (array.isNull() == true)
         return;
 
-    for (const auto &value : array->values())
+    foreach (const auto &value, array->values())
     {
         switch (policy)
         {
@@ -451,7 +451,7 @@ QDebug operator<<(QDebug dbg, const QMJsonArray &array)
 
     dbg.nospace() << "QMJsonArray[";
 
-    for (const auto &value : array.values())
+    foreach (const auto &value, array.values())
     {
         if (started == true)
             dbg << ",";

--- a/src/core/qmjsonobject.cpp
+++ b/src/core/qmjsonobject.cpp
@@ -447,7 +447,7 @@ QDebug operator<<(QDebug dbg, const QMJsonObject &object)
 
     dbg.nospace() << "QMJsonObject{";
 
-    for (const auto &key : object.keys())
+    foreach (const auto &key, object.keys())
     {
         if (started == true)
             dbg << ",";

--- a/src/core/qmjsontype_qmjsonarray.cpp
+++ b/src/core/qmjsontype_qmjsonarray.cpp
@@ -76,7 +76,7 @@ QString QM_JSON_EXPORT QMJsonType<QMPointer<QMJsonArray> >::toJson(int32_t tab, 
     {
         json += '[';
 
-        for (const auto &value : array->values())
+        foreach (const auto &value, array->values())
         {
             json += value->toJson((QMJsonFormat)tab, sort);
             json += ',';
@@ -90,7 +90,7 @@ QString QM_JSON_EXPORT QMJsonType<QMPointer<QMJsonArray> >::toJson(int32_t tab, 
 
         tab += 4;
         auto space = QString(tab, ' ');
-        for (const auto &value : array->values())
+        foreach (const auto &value, array->values())
         {
             json += "\n";
             json += space;

--- a/src/core/qmjsontype_qmjsonobject.cpp
+++ b/src/core/qmjsontype_qmjsonobject.cpp
@@ -133,7 +133,7 @@ QString QM_JSON_EXPORT QMJsonType<QMPointer<QMJsonObject> >::toJson(int32_t tab,
                 QStringList keys = object->keys();
                 keys.sort(convertQMJsonSort(sort));
 
-                for (const auto &key : keys)
+                foreach (const auto &key, keys)
                 {
                     const auto &value = object->value(key);
 
@@ -184,7 +184,7 @@ QString QM_JSON_EXPORT QMJsonType<QMPointer<QMJsonObject> >::toJson(int32_t tab,
                 QStringList keys = object->keys();
                 keys.sort(convertQMJsonSort(sort));
 
-                for (const auto &key : keys)
+                foreach (const auto &key, keys)
                 {
                     const auto &value = object->value(key);
 

--- a/src/core/qmjsonvalue.cpp
+++ b/src/core/qmjsonvalue.cpp
@@ -700,7 +700,7 @@ QVariant QMJsonValue::toVariant(void)
         {
             auto list = QVariantList();
 
-            for (const auto &value : this->toArray()->values())
+            foreach (const auto &value, this->toArray()->values())
                 list.append(value->toVariant());
 
             return QVariant::fromValue(list);
@@ -711,7 +711,7 @@ QVariant QMJsonValue::toVariant(void)
             auto hash = QVariantHash();
             const auto &object = this->toObject();
 
-            for (const auto &key : object->keys())
+            foreach (const auto &key, object->keys())
                 hash[key] = object->value(key)->toVariant();
 
             return QVariant::fromValue(hash);
@@ -746,7 +746,7 @@ QMPointer<QMJsonValue> QMJsonValue::fromVariant(const QVariant &value)
         {
             auto array = QMPointer<QMJsonArray>(new QMJsonArray);
 
-            for (const auto &variant : value.value<QSequentialIterable>())
+            foreach (const auto &variant, value.value<QSequentialIterable>())
                 array->append(QMJsonValue::fromVariant(variant));
 
             return QMPointer<QMJsonValue>(new QMJsonValue(array));

--- a/src/core/qmjsonvalue.cpp
+++ b/src/core/qmjsonvalue.cpp
@@ -1070,6 +1070,7 @@ QMPointer<QMJsonValue> QMJsonValue::fromJson(const QString &json, int32_t &index
         case ']':
         case '}':
             QMJsonValue::throwError(json, index, "Unexpected closing bracket. Are there too many commas?");
+        break;
 
         default:
             return QMJsonType<double>::fromJson(json, index);


### PR DESCRIPTION
I've encountered some problems with utf8.
I do not know what json standard is telling us about utf characters, but escaping them all is not my case. Moreover, Qt5 json parser doesn't work like this too.
This is a quick hack, you probably should review it very carefully.

At least accept compiler fixes.